### PR TITLE
Fix parser call statement handling

### DIFF
--- a/src/teal-parser/Parser.hpp
+++ b/src/teal-parser/Parser.hpp
@@ -113,7 +113,7 @@ namespace teal::parser
         Parser(std::vector<Token> toks) : max_errors(10), _tokens(std::move(toks)), _pos(0), _nodes()
         {
             //TODO: Change `_nodes` into a custom datastructure that can be "frozen", we cannot have any more reallocations as it would break all pointers
-            _nodes.reserve(_tokens.size());
+            _nodes.reserve(_tokens.size() * 2);
         }
         std::tuple<std::optional<std::reference_wrapper<const ast::Block>>, std::vector<Error>> parse()
         {
@@ -263,7 +263,7 @@ namespace teal::parser
         std::vector<std::string_view> parse_name_list();
         std::optional<ast::Expression> parse_expression();
         std::vector<ast::Expression> parse_expression_list();
-        std::optional<ast::PrefixExpression> parse_prefix_expression();
+        std::optional<ast::PrefixExpression> parse_prefix_expression(bool *is_call = nullptr);
         std::optional<ast::PrefixExpression> parse_var_expression();
         std::optional<ast::PrimaryExpression> parse_primary_expression();
         int get_binary_precedence(TokenType op);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -116,3 +116,34 @@ end
     const Block &blk = ast_opt.value().get();
     CHECK_FALSE(blk.statements.empty());
 }
+
+TEST_CASE("parser call statement") {
+    std::string_view src = R"(
+print("hi")
+)";
+    Lexer lex(src);
+    auto [tks, lex_errs] = lex.tokenize();
+    REQUIRE(lex_errs.empty());
+    Parser parser(tks);
+    auto [ast_opt, parse_errs] = parser.parse();
+    REQUIRE(parse_errs.empty());
+    REQUIRE(ast_opt.has_value());
+    const Block &blk = ast_opt.value().get();
+    CHECK_EQ(blk.statements.size(), 1);
+}
+
+TEST_CASE("parser method call statement") {
+    std::string_view src = R"(
+io.stderr:write("hi")
+)";
+    Lexer lex(src);
+    auto [tks, lex_errs] = lex.tokenize();
+    REQUIRE(lex_errs.empty());
+    Parser parser(tks);
+    auto [ast_opt, parse_errs] = parser.parse();
+    REQUIRE(parse_errs.empty());
+    REQUIRE(ast_opt.has_value());
+    const Block &blk = ast_opt.value().get();
+    CHECK_EQ(blk.statements.size(), 1);
+}
+


### PR DESCRIPTION
## Summary
- ensure parser has enough node storage capacity
- track whether prefix expressions include a call
- parse call statements using this flag
- add tests covering call statements

## Testing
- `xmake build unit_tests`
- `xmake run unit_tests`

------
https://chatgpt.com/codex/tasks/task_e_6840d24fd4908333a8ef105e92c5cbbf